### PR TITLE
Added suggested outputs to outputs.tf

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,15 @@
+output "tunnel1_address" {
+  value = "${aws_vpn_connection.main.tunnel1_address}"
+}
+
+output "tunnel2_address" {
+  value = "${aws_vpn_connection.main.tunnel2_address}"
+}
+
+output "tunnel1_bgp_asn" {
+  value = "${aws_vpn_connection.main.tunnel1_bgp_asn}"
+}
+
+output "tunnel2_bgp_asn" {
+  value = "${aws_vpn_connection.main.tunnel2_bgp_asn}"
+}


### PR DESCRIPTION
These will provide an end user with the tunnel IPs and BGP ASNs. Both of these values can be useful if you can't configure the customer side of the tunnel, since the network admin might want these.